### PR TITLE
Added competition component for administrators

### DIFF
--- a/api/database.json
+++ b/api/database.json
@@ -53,25 +53,25 @@
     {
       "id": 1,
       "name": "Gravity Check",
-      "date": "06/17/24",
+      "date": "2024-06-17",
       "location": "Triangle Rock Club",
-      "startTime": 16.5,
+      "startTime": "16:30",
       "userId": 1
     },
     {
       "id": 2,
       "name": "Boulder Dash",
-      "date": "07/13/24",
+      "date": "2024-07-13",
       "location": "Sport Rock",
-      "startTime": 13,
+      "startTime": "13:00",
       "userId": 1
     },
     {
       "id": 3,
       "name": "No Holds Barred",
-      "date": "07/20/24",
+      "date": "2024-07-20",
       "location": "State Climb",
-      "startTime": 11,
+      "startTime": "11:00",
       "userId": 1
     }
   ],

--- a/src/components/competitions/AdminCompetitionList.jsx
+++ b/src/components/competitions/AdminCompetitionList.jsx
@@ -1,0 +1,88 @@
+import { useEffect } from "react"
+import { useState } from "react"
+import { deleteCompetition, getCompetitionList } from "../../services/CompetitionServices.jsx"
+import { Button, Table } from "reactstrap"
+import "./Competitions.css"
+import { useNavigate } from "react-router-dom"
+
+export const AdminCompetitionList = ({ currentUser }) => {
+    const [competitionList, setCompetitionList] = useState([])
+
+    const navigate = useNavigate()
+
+    useEffect(() => {
+        getCompetitionList().then(competitionArr => {
+            setCompetitionList(competitionArr)
+        })
+    }, [])
+
+    return (
+        <article className="wider">
+            <h2 className="margin">Compeititons</h2>
+            <Table>
+                <thead>
+                    <tr>
+                        <th>
+                            Name
+                        </th>
+                        <th>
+                            Date
+                        </th>
+                        <th>
+                            Location
+                        </th>
+                        <th>
+                            Registration
+                        </th>
+                        <th>
+                            
+                        </th>
+                        <th>
+                            
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {competitionList.map(competition => {
+                        return (
+                            <tr key={competition.id}>
+                                <th scope="row">
+                                    {competition.name}
+                                </th>
+                                <td>
+                                    {competition.date}
+                                </td>
+                                <td>
+                                    {competition.location}
+                                </td>
+                                <td>
+                                    <Button color="link" onClick={() => navigate("/competitions/registration", { state: { competition: competition } })}>
+                                        View And Edit
+                                    </Button>
+                                </td>
+                                <td>
+                                    {competition.userId === currentUser.id ? 
+                                        <Button onClick={() => navigate("/competitions/edit", { state: { competition: competition } })}>
+                                            Edit
+                                        </Button>
+                                        :
+                                        ""
+                                    }
+                                </td>
+                                <td>
+                                    {competition.userId === currentUser.id ? 
+                                        <Button onClick={() => deleteCompetition(competition)}>
+                                            Delete
+                                        </Button>
+                                        :
+                                        ""
+                                    }
+                                </td>
+                            </tr>
+                        )
+                    })}
+                </tbody>
+            </Table>
+        </article>
+    )
+}

--- a/src/components/competitions/CompetitionRegistarants.jsx
+++ b/src/components/competitions/CompetitionRegistarants.jsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react"
+import { useLocation } from "react-router-dom"
+import { deregisterCompetitor, getCompetitors } from "../../services/UserServices.jsx"
+import { Button, Table } from "reactstrap"
+
+export const CompetitionRegistrants = () => {
+    const [competitorList, setCompetitorList] = useState([])
+    const [filteredCompetitorList, setFilteredCompetitorList] = useState([])
+    const [filteredRegistrationList, setFilteredRegistrationList] = useState([])
+
+    const { state } = useLocation()
+
+    const handleDeregistration = (competitor) => {
+        const registrationInfo = filteredRegistrationList.find(registration => registration.userId === competitor.id)
+        deregisterCompetitor(registrationInfo)
+        getAndSetCompetitorList()
+    }
+
+    const getAndSetCompetitorList = () => {
+        const arr = []
+        const registrationArr = []
+        competitorList.map(competitor => {
+            for (const registration of competitor.competitionRegistrants) {
+                if (registration.competitionId === state.competition.id) {
+                    arr.push(competitor)
+                    registrationArr.push(registration)
+                }
+            }
+        })
+        setFilteredCompetitorList(arr)
+        setFilteredRegistrationList(registrationArr)
+    }
+
+    useEffect(() => {
+        getCompetitors().then(competitorArr => {
+            setCompetitorList(competitorArr)
+        })
+    }, [])
+
+    useEffect(() => {
+        getAndSetCompetitorList()
+    }, [competitorList])
+
+    return (
+        <article className="wider">
+            <h2 className="margin">{state.competition.name} Registration List</h2>
+            <Table>
+                <thead>
+                    <tr>
+                        <th>
+                            Name
+                        </th>
+                        <th>
+                        
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {filteredCompetitorList.map(competitor => {
+                        return (
+                            <tr key={competitor.id}>
+                                <th scope="row">
+                                    {competitor.name}
+                                </th>
+                                <td>
+                                    <Button onClick={() => handleDeregistration(competitor)}>
+                                        Deregister
+                                    </Button>
+                                </td>
+                            </tr>
+                        )
+                    })}
+                </tbody>
+            </Table>
+        </article>
+    )
+}

--- a/src/components/competitions/Competitions.css
+++ b/src/components/competitions/Competitions.css
@@ -1,0 +1,3 @@
+.wider {
+    width: 100vw;
+}

--- a/src/components/competitions/EditCompetition.jsx
+++ b/src/components/competitions/EditCompetition.jsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from "react"
+import { useLocation, useNavigate } from "react-router-dom"
+import { editExistingCompetition } from "../../services/CompetitionServices.jsx"
+
+export const EditCompetition = () => {
+    const [competitionInfo, setCompetitionInfo] = useState([])
+
+    const { state } = useLocation()
+
+    const navigate = useNavigate()
+
+    const handleCompetitionEdit = () => {
+        editExistingCompetition(competitionInfo)
+        navigate("/competitions")
+    }
+    
+    useEffect(() => {
+        const info = {
+            id: state.competition.id,
+            name: state.competition.name,
+            date: state.competition.date,
+            location: state.competition.location,
+            startTime: state.competition.startTime,
+            userId: state.competition.userId
+        }
+
+        setCompetitionInfo(info)
+    }, [])
+
+    return (
+        <article className="createContainer">
+            <form>
+                <h2 className="marginBottom">Edit {state.competition.name} Information</h2>
+                <fieldset>
+                    <div>
+                        <h4>Enter Competition Name</h4>
+                        <input
+                        type="text"
+                        id="name"
+                        className="createInput"
+                        placeholder="Name"
+                        required
+                        autoFocus
+                        defaultValue={state.competition.name}
+                        onChange={(event) => {
+                            const copy = {...competitionInfo}
+                            copy.name = event.target.value
+                            setCompetitionInfo(copy)
+                        }}
+                        />
+                    </div>
+                </fieldset>
+                <fieldset>
+                    <div>
+                        <h4>Enter Date</h4>
+                        <input
+                        type="date"
+                        id="date"
+                        className="createInput"
+                        placeholder="Enter competition date"
+                        required
+                        defaultValue={state.competition.date}
+                        onChange={(event) => {
+                            const copy = {...competitionInfo}
+                            copy.date = event.target.value
+                            setCompetitionInfo(copy)
+                        }}
+                        />
+                    </div>
+                </fieldset>
+                <fieldset>
+                    <div>
+                        <h4>Enter Location</h4>
+                        <input
+                        type="text"
+                        id="location"
+                        className="createInput"
+                        placeholder="Location"
+                        required
+                        defaultValue={state.competition.location}
+                        onChange={(event) => {
+                            const copy = {...competitionInfo}
+                            copy.location = event.target.value
+                            setCompetitionInfo(copy)
+                        }}
+                        />
+                    </div>
+                </fieldset>
+                <fieldset>
+                    <div>
+                        <h4>Enter Start Time</h4>
+                        <input
+                        type="time"
+                        id="startTime"
+                        className="createInput"
+                        placeholder="Start Time"
+                        required
+                        defaultValue={state.competition.startTime}
+                        onChange={(event) => {
+                            const copy = {...competitionInfo}
+                            copy.startTime = event.target.value
+                            setCompetitionInfo(copy)
+                        }}
+                        />
+                    </div>
+                </fieldset>
+                <fieldset>
+                    <div>
+                        <button className="login-btn btn-info" type="submit" onClick={() => handleCompetitionEdit()}>
+                            Submit
+                        </button>
+                    </div>
+                </fieldset>
+            </form>
+        </article>
+    )
+}

--- a/src/components/navbar/AdministratorNavBar.jsx
+++ b/src/components/navbar/AdministratorNavBar.jsx
@@ -19,7 +19,7 @@ export const AdministratorNavBar = () => {
                   <NavLink href="/validate">Validate</NavLink>
                 </NavItem>
                 <NavItem>
-                  <NavLink href="/comps">Competitions</NavLink>
+                  <NavLink href="/competitions">Competitions</NavLink>
                 </NavItem>
                 <NavItem>
                     <NavLink 

--- a/src/components/navbar/CompetitorNavBar.jsx
+++ b/src/components/navbar/CompetitorNavBar.jsx
@@ -16,7 +16,7 @@ export const CompetitorNavBar = () => {
                   <NavLink href="/validate">Validate</NavLink>
                 </NavItem>
                 <NavItem>
-                  <NavLink href="/comps">Competitions</NavLink>
+                  <NavLink href="/competitions">Competitions</NavLink>
                 </NavItem>
                 <NavItem>
                   <NavLink href="/leagueLeaderboard">League Leaderboard</NavLink>

--- a/src/components/validate/AdminValidateNote.jsx
+++ b/src/components/validate/AdminValidateNote.jsx
@@ -8,7 +8,6 @@ export const AdminValidateNote = () => {
     const [note, setNote] = useState("")
 
     const { state } = useLocation()
-    console.log(state.climb)
 
     const handleAddedNote = () => {
         const newAscentObj = {

--- a/src/services/CompetitionServices.jsx
+++ b/src/services/CompetitionServices.jsx
@@ -19,3 +19,19 @@ export const getCompetitionClimbListById = (id) => {
 export const getCompetitionsViaLeaderboard = () => {
     return fetch("http://localhost:8088/competitions?_embed=competitionLeaderboard").then(res => res.json())
 }
+
+export const editExistingCompetition = (competitionObj) => {
+    return fetch(`http://localhost:8088/competitions/${competitionObj.id}`, {
+        method: "PUT",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(competitionObj)
+    })
+}
+
+export const deleteCompetition = (competitionObj) => {
+    return fetch(`http://localhost:8088/competitions/${competitionObj.id}`, {
+        method: "DELETE"
+    })
+}

--- a/src/services/UserServices.jsx
+++ b/src/services/UserServices.jsx
@@ -25,3 +25,9 @@ export const editUserAscent = (ascentObj) => {
         body: JSON.stringify(ascentObj)
     })
 }
+
+export const deregisterCompetitor = (competitorRegistration) => {
+    return fetch(`http://localhost:8088/competitionRegistrants/${competitorRegistration.id}`, {
+        method: "DELETE"
+    })
+}

--- a/src/views/AdministratorViews.jsx
+++ b/src/views/AdministratorViews.jsx
@@ -5,6 +5,9 @@ import { Create } from "../components/create/Create.jsx"
 import { CreateClimbList } from "../components/create/CreateClimbList.jsx"
 import { AdminValidate } from "../components/validate/AdminValidate.jsx"
 import { AdminValidateNote } from "../components/validate/AdminValidateNote.jsx"
+import { AdminCompetitionList } from "../components/competitions/AdminCompetitionList.jsx"
+import { CompetitionRegistrants } from "../components/competitions/CompetitionRegistarants.jsx"
+import { EditCompetition } from "../components/competitions/EditCompetition.jsx"
 
 export const AdministratorViews = ({ currentUser }) => {
     return (
@@ -26,6 +29,11 @@ export const AdministratorViews = ({ currentUser }) => {
                 <Route path="validate">
                     <Route index element={<AdminValidate currentUser={currentUser} />} />
                     <Route path="note" element={<AdminValidateNote currentUser={currentUser} />} />
+                </Route>
+                <Route path="competitions">
+                    <Route index element={<AdminCompetitionList currentUser={currentUser} />} />
+                    <Route path="registration" element={<CompetitionRegistrants currentUser={currentUser} />} />
+                    <Route path="edit" element={<EditCompetition currentUser={currentUser} />} />
                 </Route>
             </Route>
         </Routes>


### PR DESCRIPTION
## What Changed

- Administrator can now navigate to the competitions page via the navbar to see a list of all competitions
- Within the list there are links to view registrants for each competition and buttons to edit competition info and delete competitions given the current user created the competition
- Inside the registrants link there is a page with a list of competitors that are registered for the comp and a button to deregister each competitor

## How To Test

- Login as an administrator
- Click the link for the competitions route in the navbar
- View the list of competitions and check that they line up with those in the db
- If the admin user created the competition you should see an edit and delete button in that line, otherwise there shouldn't be any buttons
- View and edit the registration list and test that you're able to deregister competitors
- Edit competition info and check that it updates properly
- Delete a competition and check that it is removed from the database