### PR TITLE
Fixed league leaderboard routing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,18 +6,29 @@ import { Login } from './components/auth/Login.jsx'
 import { Register } from './components/auth/Register.jsx'
 import { LeagueLeaderboard } from './components/leaderboards/LeagueLeaderboard.jsx'
 import { NavBar } from './components/navbar/NavBar.jsx'
+import { useEffect, useState } from 'react'
+import { AdministratorNavBar } from './components/navbar/AdministratorNavBar.jsx'
+import { CompetitorNavBar } from './components/navbar/CompetitorNavBar.jsx'
 
 export const App = () => {
+  const [currentUser, setCurrentUser] = useState({})
+
+  useEffect(() => {
+    const localVertiUser = localStorage.getItem("verti_user")
+    const vertiUserObject = JSON.parse(localVertiUser)
+
+    setCurrentUser(vertiUserObject)
+  }, [])
 
   return (
     <Routes>
       <Route path='/login' element={<><NavBar /><Login /></>} />
       <Route path='/register' element={<><NavBar /><Register /></>} />
-      <Route path='/leagueLeaderboard' element={<><NavBar /><LeagueLeaderboard /></>} />
+      <Route path='/leagueLeaderboard' element={<>{!currentUser ? <NavBar /> : currentUser?.isStaff ? <AdministratorNavBar /> : <CompetitorNavBar />}<LeagueLeaderboard /></>} />
 
         <Route path='*' element={
           <Authorized>
-            <ApplicationViews />
+            <ApplicationViews currentUser={currentUser}/>
           </Authorized>
         } />
     </Routes>

--- a/src/views/ApplicationViews.jsx
+++ b/src/views/ApplicationViews.jsx
@@ -1,17 +1,9 @@
-import { useEffect, useState } from "react"
 import { AdministratorViews } from "./AdministratorViews.jsx"
 import { CompetitorViews } from "./CompetitorViews.jsx"
 
 
-export const ApplicationViews = () => {
-  const [currentUser, setCurrentUser] = useState({})
+export const ApplicationViews = ({ currentUser }) => {
 
-  useEffect(() => {
-    const localVertiUser = localStorage.getItem("verti_user")
-    const vertiUserObject = JSON.parse(localVertiUser)
 
-    setCurrentUser(vertiUserObject)
-  }, [])
-
-  return currentUser.isStaff ? <AdministratorViews currentUser={currentUser} /> : <CompetitorViews currentUser={currentUser}/>
+  return currentUser?.isStaff ? <AdministratorViews currentUser={currentUser} /> : <CompetitorViews currentUser={currentUser}/>
 }

--- a/src/views/CompetitorViews.jsx
+++ b/src/views/CompetitorViews.jsx
@@ -2,6 +2,7 @@ import { Outlet, Route, Routes } from "react-router-dom"
 import { Dashboard } from "../components/dashboard/Dashboard.jsx"
 import { CompetitorNavBar } from "../components/navbar/CompetitorNavBar.jsx"
 import { LeagueLeaderboard } from "../components/leaderboards/LeagueLeaderboard.jsx"
+import { CompetitorValidate } from "../components/validate/CompetitorValidate.jsx"
 
 export const CompetitorViews = ({ currentUser }) => {
     return (
@@ -16,6 +17,9 @@ export const CompetitorViews = ({ currentUser }) => {
                 }
             >
                 <Route index element={<Dashboard />} />
+                <Route path="validate">
+                    <Route index element={<CompetitorValidate currentUser={currentUser} />} />
+                </Route>
                 <Route path="leagueLeaderboard">
                     <Route index element={<LeagueLeaderboard />} />
                 </Route>


### PR DESCRIPTION
## What Changed

- Added ternary statements in App.jsx on /leagueLeaderboard route to prevent default navbar from rendering for administrators and competitors

## How To Test

- Remain logged out and navigate to the leaderboard; navbar should display Login, Register, and Leaderboard
- Login as admin and navigate to the leaderboard; navbar should display Create, Validate, Competitions, Leaderboard, and Logout
- Login as competitor and navigate to the leaderboard; navbar should display Validate, Competitions, Leaderboard, and Logout