### PR TITLE
Made deregister responsive, fixed typo

### DIFF
--- a/src/components/competitions/CompetitionRegistrants.jsx
+++ b/src/components/competitions/CompetitionRegistrants.jsx
@@ -12,8 +12,9 @@ export const CompetitionRegistrants = () => {
 
     const handleDeregistration = (competitor) => {
         const registrationInfo = filteredRegistrationList.find(registration => registration.userId === competitor.id)
-        deregisterCompetitor(registrationInfo)
-        getAndSetCompetitorList()
+        deregisterCompetitor(registrationInfo).then(() => getCompetitors().then(competitorArr => {
+            setCompetitorList(competitorArr)
+        }))
     }
 
     const getAndSetCompetitorList = () => {


### PR DESCRIPTION
## What Changed

- Updated functions so the competitor registrant list is responsive when deregistering competitors
- Fixed file name typo

## How To Test

- Login as administrator
- Navigate to the competitions page
- Click one of the view and edit buttons to see which competitors are registered for each competition
- Deregister one of the competitors and watch them disappear from the list