### PR TITLE
Added dashboard feature'

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,7 +28,7 @@ export const App = () => {
 
         <Route path='*' element={
           <Authorized>
-            <ApplicationViews currentUser={currentUser}/>
+            <ApplicationViews/>
           </Authorized>
         } />
     </Routes>

--- a/src/components/dashboard/Dashboard.css
+++ b/src/components/dashboard/Dashboard.css
@@ -1,0 +1,21 @@
+.competitionContainer {
+    width: 40%;
+    height: 70vh;
+    border: solid ;
+    padding: 1em;
+}
+
+.dashboardContainer {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    width: 100vw;
+    padding: 1em;
+}
+
+.leaderboardContainer {
+    width: 60%;
+    height: 70vh;
+    border: solid ;
+    padding: 1em;
+}

--- a/src/components/dashboard/Dashboard.jsx
+++ b/src/components/dashboard/Dashboard.jsx
@@ -1,3 +1,117 @@
+import { useEffect, useState } from "react"
+import { Table } from "reactstrap"
+import { getLeagueLeaderboard } from "../../services/LeaderboardServices.jsx"
+import "./Dashboard.css"
+import { getCompetitionList } from "../../services/CompetitionServices.jsx"
+
 export const Dashboard = ({ currentUser }) => {
-    return <div>hi</div>
+    const [leaderboardList, setLeaderboardList] = useState([])
+    const [competitionList, setCompetitionList] = useState([])
+
+    const getAndSetLeaderboard = () => {
+        getLeagueLeaderboard().then(leaderboardObj => {
+            setLeaderboardList(leaderboardObj)
+        })
+    }
+
+    const sortLeaderboard = () => {
+        leaderboardList.sort((a, b) => b.user.leaguePoints - a.user.leaguePoints) 
+    }
+
+    const formattedDate = (datestring) => {
+        const [year, month, day] = datestring.split("-")
+        return `${month} - ${day} - ${year}`
+    }
+
+    useEffect(() => {
+        getCompetitionList().then(competitionArr => {
+            setCompetitionList(competitionArr)
+        })
+    }, [])
+
+    useEffect(() => {
+        getAndSetLeaderboard()
+    }, [])
+
+    useEffect(() => {
+        sortLeaderboard()
+    }, [leaderboardList])
+
+    return (
+        <>
+            <h1 className="margin">Verti Comps</h1>
+            <section className="dashboardContainer">
+                <article className="leaderboardContainer">
+                    <h2>Leaderboard</h2>
+                    <Table>
+                        <thead>
+                            <tr>
+                                <th>
+                                    #
+                                </th>
+                                <th>
+                                    Name
+                                </th>
+                                <th>
+                                    Point Total
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        {leaderboardList.map(competitor => {
+                            return (
+                                <tr key={competitor.id}>
+                                    <th scope="row">
+                                        {competitor.id}
+                                    </th>
+                                    <td>
+                                        {competitor.user.name}
+                                    </td>
+                                    <td>
+                                        {competitor.user.leaguePoints}
+                                    </td>
+                                </tr>
+                            )
+                        })}
+                        </tbody>
+                    </Table>
+                </article>
+                <article className="competitionContainer">
+                    <h2 className="margin">Competitions</h2>
+                    <Table>
+                        <thead>
+                            <tr>
+                                <th>
+                                    Name
+                                </th>
+                                <th>
+                                    Date
+                                </th>
+                                <th>
+                                    Location
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {competitionList.map(competition => {
+                                return (
+                                    <tr key={competition.id}>
+                                        <th scope="row">
+                                            {competition.name}
+                                        </th>
+                                        <td>
+                                            {formattedDate(competition.date)}
+                                        </td>
+                                        <td>
+                                            {competition.location}
+                                        </td>
+                                    </tr>
+                                )
+                            })}
+                        </tbody>
+                    </Table>
+                </article>
+            </section>
+        </>
+    )
 }

--- a/src/views/ApplicationViews.jsx
+++ b/src/views/ApplicationViews.jsx
@@ -1,9 +1,17 @@
+import { useEffect, useState } from "react"
 import { AdministratorViews } from "./AdministratorViews.jsx"
 import { CompetitorViews } from "./CompetitorViews.jsx"
 
 
-export const ApplicationViews = ({ currentUser }) => {
+export const ApplicationViews = () => {
+  const [currentUser, setCurrentUser] = useState({})
 
+  useEffect(() => {
+    const localVertiUser = localStorage.getItem("verti_user")
+    const vertiUserObject = JSON.parse(localVertiUser)
 
-  return currentUser?.isStaff ? <AdministratorViews currentUser={currentUser} /> : <CompetitorViews currentUser={currentUser}/>
+    setCurrentUser(vertiUserObject)
+  }, [])
+
+  return currentUser.isStaff ? <AdministratorViews currentUser={currentUser} /> : <CompetitorViews currentUser={currentUser}/>
 }


### PR DESCRIPTION
## What Changed

- Added leaderboard and competition list to dashboard
- Fixed currentUser as prop drilling was slow and caused the admin user to see the competitor navbar on render

## How To Test

- Login as either user
- View the leaderboard and competition list on the dashboard page
- Swap user type
- View the same info