### PR TITLE
Admin comp list v2

### DIFF
--- a/api/database.json
+++ b/api/database.json
@@ -56,6 +56,7 @@
       "date": "2024-06-17",
       "location": "Triangle Rock Club",
       "startTime": "16:30",
+      "inProgress": false,
       "userId": 1
     },
     {
@@ -64,6 +65,7 @@
       "date": "2024-07-13",
       "location": "Sport Rock",
       "startTime": "13:00",
+      "inProgress": false,
       "userId": 1
     },
     {
@@ -72,6 +74,7 @@
       "date": "2024-07-20",
       "location": "State Climb",
       "startTime": "11:00",
+      "inProgress": false,
       "userId": 1
     }
   ],

--- a/api/database.json
+++ b/api/database.json
@@ -57,6 +57,7 @@
       "location": "Triangle Rock Club",
       "startTime": "16:30",
       "inProgress": false,
+      "hasStarted": true,
       "userId": 1
     },
     {
@@ -66,6 +67,7 @@
       "location": "Sport Rock",
       "startTime": "13:00",
       "inProgress": false,
+      "hasStarted": false,
       "userId": 1
     },
     {
@@ -75,6 +77,7 @@
       "location": "State Climb",
       "startTime": "11:00",
       "inProgress": false,
+      "hasStarted": false,
       "userId": 1
     }
   ],

--- a/src/components/competitions/AdminCompetitionDetails.jsx
+++ b/src/components/competitions/AdminCompetitionDetails.jsx
@@ -8,6 +8,7 @@ export const AdminCompetitionDetails = () => {
     const [competitionRegistration, setCompetitionRegistration] = useState([])
     const [competitionLeaderboard, setCompetitionLeaderboard] = useState([])
     const [competitionLeaderboardAndNames, setCompetitionLeaderboardAndNames] = useState([])
+    const [rankArr, setRankArr] = useState([])
 
     const navigate = useNavigate()
 
@@ -24,10 +25,13 @@ export const AdminCompetitionDetails = () => {
 
     useEffect(() => {
         const arr = []
+        let counter = 1
         for (const item of competitionLeaderboard) {
             const userObj = state.leagueLeaderboard.find(entry => entry.userId === item.userId)
             item.name = userObj?.user.name
+            item.rank = counter
             arr.push(item)
+            counter++
         }
         setCompetitionLeaderboardAndNames(arr)
     }, [competitionLeaderboard])
@@ -111,7 +115,7 @@ export const AdminCompetitionDetails = () => {
                         return (
                             <tr key={obj.id}>
                                 <th className="textDark">
-                                    {obj.id}
+                                    {obj.rank}
                                 </th>
                                 <th className="textDark">
                                     {obj.name}

--- a/src/components/competitions/AdminCompetitionDetails.jsx
+++ b/src/components/competitions/AdminCompetitionDetails.jsx
@@ -1,0 +1,69 @@
+import { useLocation, useNavigate } from "react-router-dom"
+import { postToCompetitionLeaderboard, postToLeagueLeaderboard } from "../../services/LeaderboardServices.jsx"
+import { Button } from "reactstrap"
+import { editExistingCompetition } from "../../services/CompetitionServices.jsx"
+
+export const AdminCompetitionDetails = () => {
+    const navigate = useNavigate()
+
+    const { state } = useLocation()
+
+    const handleLeaderboardAdditions = () => {
+        if (state.competition.inProgress) {
+            if (state.competitionLeaderboard.length > 0) {
+                const obj = {...state.competition}
+                obj.inProgress = !state.competition.inProgress
+                editExistingCompetition(obj)
+                navigate("/competitions")
+            } else {
+                for (const registrant of state.competitionRegistrants) {
+                    const competitor = state.leagueLeaderboard.find(entryObj => entryObj.userId === registrant.userId)
+                    if (competitor) {
+                        const compLeaderboardObj = {
+                            userId: registrant.userId,
+                            competitionId: state.competition.id
+                        }
+                        postToCompetitionLeaderboard(compLeaderboardObj)
+                    } else {
+                        const leagueLeaderboardObj = {
+                            userId: registrant.userId
+                        }
+                        postToLeagueLeaderboard(leagueLeaderboardObj)
+
+                        const competitionLeaderboardObj = {
+                            userId: registrant.userId,
+                            competitionId: state.competition.id
+                        }
+                        postToCompetitionLeaderboard(competitionLeaderboardObj)
+                    }
+                }
+                const obj = {...state.competition}
+                obj.inProgress = !state.competition.inProgress
+                editExistingCompetition(obj)
+                navigate("/competitions")
+            }
+        } else {
+            const obj = {...state.competition}
+            obj.inProgress = !state.competition.inProgress
+            editExistingCompetition(obj)
+            navigate("/competitions")
+        }
+    }
+
+    return (
+        <>
+            <h2>{state.competition.name} Details</h2>
+            <section>
+                {state.competition.inProgress ?
+                    <Button className="btn-color btn-lt-txt" onClick={() => handleLeaderboardAdditions()}>
+                        End Competition
+                    </Button>
+                :
+                    <Button className="btn-color btn-lt-txt" onClick={() => handleLeaderboardAdditions()}>
+                        Start Competition
+                    </Button>
+                }
+            </section>
+        </>
+    )
+}

--- a/src/components/competitions/AdminCompetitionDetails.jsx
+++ b/src/components/competitions/AdminCompetitionDetails.jsx
@@ -1,18 +1,43 @@
 import { useLocation, useNavigate } from "react-router-dom"
 import { postToCompetitionLeaderboard, postToLeagueLeaderboard } from "../../services/LeaderboardServices.jsx"
-import { Button } from "reactstrap"
+import { Button, Table } from "reactstrap"
 import { editExistingCompetition } from "../../services/CompetitionServices.jsx"
+import { useEffect, useState } from "react"
 
 export const AdminCompetitionDetails = () => {
+    const [competitionRegistration, setCompetitionRegistration] = useState([])
+    const [competitionLeaderboard, setCompetitionLeaderboard] = useState([])
+    const [competitionLeaderboardAndNames, setCompetitionLeaderboardAndNames] = useState([])
+
     const navigate = useNavigate()
 
     const { state } = useLocation()
 
-    const handleLeaderboardAdditions = () => {
-        if (state.competition.inProgress) {
+    useEffect(() => {
+        setCompetitionRegistration(state.competitionRegistrants)
+    }, [])
+
+    useEffect(() => {
+        const sortedList = competitionRegistration.sort((a, b) => b.competitionPoints - a.competitionPoints)
+        setCompetitionLeaderboard(sortedList)
+    }, [competitionRegistration])
+
+    useEffect(() => {
+        const arr = []
+        for (const item of competitionLeaderboard) {
+            const userObj = state.leagueLeaderboard.find(entry => entry.userId === item.userId)
+            item.name = userObj?.user.name
+            arr.push(item)
+        }
+        setCompetitionLeaderboardAndNames(arr)
+    }, [competitionLeaderboard])
+
+    const handleLeaderboardAdditions = (bool) => {
+        if (bool) {
             if (state.competitionLeaderboard.length > 0) {
                 const obj = {...state.competition}
                 obj.inProgress = !state.competition.inProgress
+                obj.hasStarted = true
                 editExistingCompetition(obj)
                 navigate("/competitions")
             } else {
@@ -39,12 +64,14 @@ export const AdminCompetitionDetails = () => {
                 }
                 const obj = {...state.competition}
                 obj.inProgress = !state.competition.inProgress
+                obj.hasStarted = true
                 editExistingCompetition(obj)
                 navigate("/competitions")
             }
         } else {
             const obj = {...state.competition}
             obj.inProgress = !state.competition.inProgress
+            obj.hasStarted = true
             editExistingCompetition(obj)
             navigate("/competitions")
         }
@@ -52,18 +79,54 @@ export const AdminCompetitionDetails = () => {
 
     return (
         <>
-            <h2>{state.competition.name} Details</h2>
+            <h2 className="textDark margin">{state.competition.name} Details</h2>
             <section>
                 {state.competition.inProgress ?
-                    <Button className="btn-color btn-lt-txt" onClick={() => handleLeaderboardAdditions()}>
+                    <Button className="btn-color btn-lt-txt margin" onClick={() => handleLeaderboardAdditions(false)}>
                         End Competition
                     </Button>
                 :
-                    <Button className="btn-color btn-lt-txt" onClick={() => handleLeaderboardAdditions()}>
+                    <Button className="btn-color btn-lt-tx margin" onClick={() => handleLeaderboardAdditions(true)}>
                         Start Competition
                     </Button>
                 }
             </section>
+            <Table className="margin">
+                <thead>
+                    <tr>
+                        <th className="textDark">
+                            Rank
+                        </th>
+                        <th className="textDark">
+                            Name
+                        </th>
+                        <th className="textDark">
+                            Points
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {state.competition.hasStarted ?
+                    competitionLeaderboardAndNames.map(obj => {
+                        return (
+                            <tr key={obj.id}>
+                                <th className="textDark">
+                                    {obj.id}
+                                </th>
+                                <th className="textDark">
+                                    {obj.name}
+                                </th>
+                                <th className="textDark">
+                                    {obj.competitionPoints}
+                                </th>
+                            </tr>
+                        )
+                    })
+                    :
+                        ""
+                    }
+                </tbody>
+            </Table>
         </>
     )
 }

--- a/src/components/competitions/AdminCompetitionList.jsx
+++ b/src/components/competitions/AdminCompetitionList.jsx
@@ -4,6 +4,7 @@ import { deleteCompetition, getCompetitionList } from "../../services/Competitio
 import { Button, Table } from "reactstrap"
 import "./Competitions.css"
 import { useNavigate } from "react-router-dom"
+import { AdminCompetitionListRow } from "./AdminCompetitionListRow.jsx"
 
 export const AdminCompetitionList = ({ currentUser }) => {
     const [competitionList, setCompetitionList] = useState([])
@@ -27,6 +28,9 @@ export const AdminCompetitionList = ({ currentUser }) => {
             <Table>
                 <thead>
                     <tr>
+                        <th>
+                            
+                        </th>
                         <th className="textDark">
                             Name
                         </th>
@@ -50,40 +54,7 @@ export const AdminCompetitionList = ({ currentUser }) => {
                 <tbody>
                     {competitionList.map(competition => {
                         return (
-                            <tr key={competition.id}>
-                                <th scope="row" className="textDark">
-                                    {competition.name}
-                                </th>
-                                <td className="textDark">
-                                    {formattedDate(competition.date)}
-                                </td>
-                                <td className="textDark">
-                                    {competition.location}
-                                </td>
-                                <td>
-                                    <Button color="link" onClick={() => navigate("/competitions/registration", { state: { competition: competition } })}>
-                                        View And Edit
-                                    </Button>
-                                </td>
-                                <td>
-                                    {competition.userId === currentUser.id ? 
-                                        <Button className="btn-color btn-lt-txt" onClick={() => navigate("/competitions/edit", { state: { competition: competition } })}>
-                                            Edit
-                                        </Button>
-                                        :
-                                        ""
-                                    }
-                                </td>
-                                <td>
-                                    {competition.userId === currentUser.id ? 
-                                        <Button className="btn-color btn-lt-txt" onClick={() => deleteCompetition(competition)}>
-                                            Delete
-                                        </Button>
-                                        :
-                                        ""
-                                    }
-                                </td>
-                            </tr>
+                            <AdminCompetitionListRow competition={competition} key={competition.id} currentUser={currentUser} competitionList={competitionList} navigate={navigate} formattedDate={formattedDate} />
                         )
                     })}
                 </tbody>

--- a/src/components/competitions/AdminCompetitionListRow.jsx
+++ b/src/components/competitions/AdminCompetitionListRow.jsx
@@ -1,0 +1,72 @@
+import { Button } from "reactstrap"
+import { deleteCompetition, getCompetitionsViaLeaderboard, getRegistrantsByCompId } from "../../services/CompetitionServices.jsx"
+import { useEffect, useState } from "react"
+import { getLeagueLeaderboard, postToCompetitionLeaderboard, postToLeagueLeaderboard } from "../../services/LeaderboardServices.jsx"
+
+export const AdminCompetitionListRow = ({ competition, currentUser, competitionList, navigate, formattedDate }) => {
+    const [compStatus, setCompStatus] = useState(competition.inProgress)
+    const [competitionLeaderboard, setCompetitionLeaderboard] = useState([])
+    const [competitionRegistrants, setCompetitionRegistrants] = useState([])
+    const [leagueLeaderboard, setLeagueLeaderboard] = useState([])
+
+    
+    useEffect(() => {
+        getCompetitionsViaLeaderboard().then(compArr => {
+            const compLeaderboard = compArr.find(comp => comp.id === competition.id)
+            setCompetitionLeaderboard(compLeaderboard.competitionLeaderboard)
+        })
+    }, [compStatus])
+    
+    useEffect(() => {
+        getRegistrantsByCompId(competition).then(regArr => {
+            setCompetitionRegistrants(regArr)
+        })
+    }, [])
+
+    useEffect(() => {
+        getLeagueLeaderboard().then(leaderboardArr => {
+            setLeagueLeaderboard(leaderboardArr)
+        })
+    }, [])
+
+    
+
+    return (
+        <tr key={competition.id}>
+                                <th scope="row" className="textDark">
+                                    <Button className="btn-color btn-lt-txt" onClick={() => navigate("/competitions/details", { state: { competition: competition, competitionLeaderboard: competitionLeaderboard, competitionRegistrants:competitionRegistrants, leagueLeaderboard: leagueLeaderboard }})}>
+                                        {competition.name}
+                                    </Button>
+                                </th>
+                                <td className="textDark">
+                                    {formattedDate(competition.date)}
+                                </td>
+                                <td className="textDark">
+                                    {competition.location}
+                                </td>
+                                <td>
+                                    <Button color="link" onClick={() => navigate("/competitions/registration", { state: { competition: competition } })}>
+                                        View And Edit
+                                    </Button>
+                                </td>
+                                <td>
+                                    {competition.userId === currentUser.id ? 
+                                        <Button className="btn-color btn-lt-txt" onClick={() => navigate("/competitions/edit", { state: { competition: competition } })}>
+                                            Edit
+                                        </Button>
+                                        :
+                                        ""
+                                    }
+                                </td>
+                                <td>
+                                    {competition.userId === currentUser.id ? 
+                                        <Button className="btn-color btn-lt-txt" onClick={() => deleteCompetition(competition)}>
+                                            Delete
+                                        </Button>
+                                        :
+                                        ""
+                                    }
+                                </td>
+                            </tr>
+    )
+}

--- a/src/components/competitions/AdminCompetitionListRow.jsx
+++ b/src/components/competitions/AdminCompetitionListRow.jsx
@@ -1,7 +1,7 @@
 import { Button } from "reactstrap"
 import { deleteCompetition, getCompetitionsViaLeaderboard, getRegistrantsByCompId } from "../../services/CompetitionServices.jsx"
 import { useEffect, useState } from "react"
-import { getLeagueLeaderboard, postToCompetitionLeaderboard, postToLeagueLeaderboard } from "../../services/LeaderboardServices.jsx"
+import { getLeagueLeaderboard } from "../../services/LeaderboardServices.jsx"
 
 export const AdminCompetitionListRow = ({ competition, currentUser, competitionList, navigate, formattedDate }) => {
     const [compStatus, setCompStatus] = useState(competition.inProgress)

--- a/src/components/create/Create.jsx
+++ b/src/components/create/Create.jsx
@@ -12,6 +12,7 @@ export const Create = ({ currentUser }) => {
     const handleCompetitionSubmit = () => {
         const copy = {...competitionInfo}
         copy.inProgress = false
+        copy.hasStarted = false
         copy.userId = currentUser.id
         postNewCompetition(copy)
         navigate('/create/climbList')

--- a/src/components/create/Create.jsx
+++ b/src/components/create/Create.jsx
@@ -11,6 +11,7 @@ export const Create = ({ currentUser }) => {
 
     const handleCompetitionSubmit = () => {
         const copy = {...competitionInfo}
+        copy.inProgress = false
         copy.userId = currentUser.id
         postNewCompetition(copy)
         navigate('/create/climbList')

--- a/src/services/CompetitionServices.jsx
+++ b/src/services/CompetitionServices.jsx
@@ -35,3 +35,7 @@ export const deleteCompetition = (competitionObj) => {
         method: "DELETE"
     })
 }
+
+export const getRegistrantsByCompId = (competitionObj) => {
+    return fetch(`http://localhost:8088/competitionRegistrants?competitionId=${competitionObj.id}`).then(res => res.json())
+}

--- a/src/services/LeaderboardServices.jsx
+++ b/src/services/LeaderboardServices.jsx
@@ -1,3 +1,23 @@
 export const getLeagueLeaderboard = () => {
     return fetch("http://localhost:8088/leagueLeaderboard?_expand=user").then(res => res.json())
 }
+
+export const postToLeagueLeaderboard = (competitorObj) => {
+    return fetch("http://localhost:8088/leagueLeaderboard", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(competitorObj)
+    })
+}
+
+export const postToCompetitionLeaderboard = (competitorObj) => {
+    return fetch("http://localhost:8088/competitionLeaderboard", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(competitorObj)
+    })
+}

--- a/src/views/AdministratorViews.jsx
+++ b/src/views/AdministratorViews.jsx
@@ -9,6 +9,7 @@ import { AdminCompetitionList } from "../components/competitions/AdminCompetitio
 import { CompetitionRegistrants } from "../components/competitions/CompetitionRegistrants.jsx"
 import { EditCompetition } from "../components/competitions/EditCompetition.jsx"
 import { LeagueLeaderboard } from "../components/leaderboards/LeagueLeaderboard.jsx"
+import { AdminCompetitionDetails } from "../components/competitions/AdminCompetitionDetails.jsx"
 
 export const AdministratorViews = ({ currentUser }) => {
     return (
@@ -35,6 +36,7 @@ export const AdministratorViews = ({ currentUser }) => {
                     <Route index element={<AdminCompetitionList currentUser={currentUser} />} />
                     <Route path="registration" element={<CompetitionRegistrants currentUser={currentUser} />} />
                     <Route path="edit" element={<EditCompetition currentUser={currentUser} />} />
+                    <Route path="details" element={<AdminCompetitionDetails />} />
                 </Route>
                 <Route path="leagueLeaderboard">
                     <Route index element={<LeagueLeaderboard currentUser={currentUser} />} />


### PR DESCRIPTION
## What Changed

- Added a component to display competition details for administrators
- Allows administrators to start and stop competitions
- Allows administrators to view competition leaderboard for competitions that have been started

## How To Test

- Login as admin
- Click competitions in navbar
- Click on one of the buttons with the competition name displayed
- View the leaderboard if the competition has been started
- If no leaderboard shows, start competition
- Refresh and return to the details page for that competition
- Leaderboard should now show with all competitors and 0 points displayed next to their name
