### PR TITLE
Added competition details for competitor

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -26,6 +26,10 @@
   color: var(--col-3);
 }
 
+.grayBackground {
+  background-color: lightgray;
+}
+
 #root {
   width: 100vw;
   margin: 0;

--- a/src/components/competitions/AdminCompetitionDetails.jsx
+++ b/src/components/competitions/AdminCompetitionDetails.jsx
@@ -8,7 +8,6 @@ export const AdminCompetitionDetails = () => {
     const [competitionRegistration, setCompetitionRegistration] = useState([])
     const [competitionLeaderboard, setCompetitionLeaderboard] = useState([])
     const [competitionLeaderboardAndNames, setCompetitionLeaderboardAndNames] = useState([])
-    const [rankArr, setRankArr] = useState([])
 
     const navigate = useNavigate()
 

--- a/src/components/competitions/CompetitorCompListRow.jsx
+++ b/src/components/competitions/CompetitorCompListRow.jsx
@@ -2,10 +2,13 @@ import { useEffect, useState } from "react"
 import { Button } from "reactstrap"
 import { deregisterCompetitor, registerCompetitor } from "../../services/UserServices.jsx"
 import { getCompetitionList } from "../../services/CompetitionServices.jsx"
+import { useNavigate } from "react-router-dom"
 
 
 export const CompetitorCompListRow = ({ currentUser, competition, formattedDate, competitorRegistrationList, setCompetitionList }) => {
     const [competitionRegistrationStatus, setCompetitorRegistrationStatus] = useState([])
+
+    const navigate = useNavigate()
 
      useEffect(() => {
         const registration = competitorRegistrationList?.find(registrationObj => registrationObj.competitionId === competition.id)
@@ -33,7 +36,9 @@ export const CompetitorCompListRow = ({ currentUser, competition, formattedDate,
     return (
         <tr key={competition.id}>
             <th scope="row" className="textDark">
-                {competition.name}
+                <Button className="btn-color btn-lt-txt" onClick={() => navigate("/competitions/details", { state: { competition: competition, competitorRegistrationList: competitorRegistrationList }})}>
+                    {competition.name}
+                </Button>
             </th>
             <td className="textDark">
                 {formattedDate(competition.date)}

--- a/src/components/competitions/CompetitorCompetitonDetails.jsx
+++ b/src/components/competitions/CompetitorCompetitonDetails.jsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from "react"
+import { useLocation } from "react-router-dom"
+import { getCompetitorListByCompId } from "../../services/UserServices.jsx"
+import { Table } from "reactstrap"
+
+export const CompetitorCompetitionDetails = ({ currentUser }) => {
+    const { state } = useLocation()
+    const [competitorList, setCompetitorList] = useState([])
+    const [competitionLeaderboard, setCompetitionLeaderboard] = useState([])
+    const [sortedCompetitionLeaderboard, setSortedCompetitionLeaderboard] = useState([])
+
+    useEffect(() => {
+        getCompetitorListByCompId(state.competition.id).then(registrationArr => {
+            setCompetitorList(registrationArr)
+        })
+    }, [])
+
+    useEffect(() => {
+        const sortedList = competitorList.sort((a, b) => b.competitionPoints - a.competitionPoints)
+        setCompetitionLeaderboard(sortedList)
+    }, [competitorList])
+
+    useEffect(() => {
+        const arr = []
+        let counter = 1
+        for (const item of competitionLeaderboard) {
+            const copy = {
+                rank: counter,
+                name: item.user.name,
+                points: item.competitionPoints,
+                userId: item.userId
+            }
+            arr.push(copy)
+            counter++
+        }
+        setSortedCompetitionLeaderboard(arr)
+    }, [competitionLeaderboard])
+
+    return (
+        <>
+            <h2 className="textDark margin">{state.competition.name} Details</h2>
+            <Table className="margin">
+                <thead>
+                    <tr>
+                        <th className="textDark">
+                            Rank
+                        </th>
+                        <th className="textDark">
+                            Name
+                        </th>
+                        <th className="textDark">
+                            Points
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                {state.competition.hasStarted ?
+                    sortedCompetitionLeaderboard.map(obj => {
+                        return (
+                            <tr key={obj.id}>
+                                <th className={obj.userId === currentUser.id ? "textDark grayBackground" : "textDark"}>
+                                    {obj.rank}
+                                </th>
+                                <th className="textDark">
+                                    {obj.name}
+                                </th>
+                                <th className="textDark">
+                                    {obj.points}
+                                </th>
+                            </tr>
+                        )
+                    })
+                    :
+                        ""
+                    }
+                </tbody>
+            </Table>
+        </>
+    )
+}

--- a/src/components/leaderboards/LeagueLeaderboard.css
+++ b/src/components/leaderboards/LeagueLeaderboard.css
@@ -1,3 +1,0 @@
-.grayBackground {
-    background-color: lightgray;
-}

--- a/src/components/validate/CompetitorValidate.jsx
+++ b/src/components/validate/CompetitorValidate.jsx
@@ -8,6 +8,7 @@ export const CompetitorValidate = ({ currentUser }) => {
     const [competition, setCompetition] = useState({})
     const [competitionClimbList, setCompetitionClimbList] = useState([])
     const [competitionDropdownOpen, setCompetitionDropdownOpen] = useState(false)
+    const [filterCompetitionList, setFilterCompetitionList] = useState([])
 
     const toggleCompetition = () => setCompetitionDropdownOpen((prevState) => !prevState);
 
@@ -25,6 +26,16 @@ export const CompetitorValidate = ({ currentUser }) => {
         })
     }, [competition])
 
+    useEffect(() => {
+        const arr = []
+        for (const competition of competitionList) {
+            if (competition.hasStarted) {
+                arr.push(competition)
+            }
+        }
+        setFilterCompetitionList(arr)
+    }, [competitionList])
+
     return (
         <article className="validateContainer">
             <header className="margin">
@@ -34,10 +45,10 @@ export const CompetitorValidate = ({ currentUser }) => {
                 <Dropdown isOpen={competitionDropdownOpen} toggle={toggleCompetition} >
                     <DropdownToggle className="dropdownColor" caret>Select Competition</DropdownToggle>
                     <DropdownMenu>
-                        {competitionList.map(competition => {
+                        {filterCompetitionList.map(competition => {
                             return (
-                                <DropdownItem className="textDark" key={competition.id} onClick={() => setCompetition(competition)}>{competition.name}</DropdownItem>
-                                )
+                                <DropdownItem className="textDark" key={competition.id} onClick={() => setCompetition(competition)}>{competition.name}</DropdownItem> 
+                            )   
                         })}
                     </DropdownMenu>
                 </Dropdown>

--- a/src/services/UserServices.jsx
+++ b/src/services/UserServices.jsx
@@ -90,3 +90,7 @@ export const updateCompetitorLeaguePoints = (competitorObj) => {
         body: JSON.stringify(competitorObj)
     })
 }
+
+export const getCompetitorListByCompId = (compId) => {
+    return fetch(`http://localhost:8088/competitionRegistrants?competitionId=${compId}&_expand=user`).then(res => res.json())
+}

--- a/src/views/CompetitorViews.jsx
+++ b/src/views/CompetitorViews.jsx
@@ -5,6 +5,7 @@ import { LeagueLeaderboard } from "../components/leaderboards/LeagueLeaderboard.
 import { CompetitorValidate } from "../components/validate/CompetitorValidate.jsx"
 import { CompetitorValidateNote } from "../components/validate/CompetitorValidateNote.jsx"
 import { CompetitorCompetitionList } from "../components/competitions/CompetitorCompetitionList.jsx"
+import { CompetitorCompetitionDetails } from "../components/competitions/CompetitorCompetitonDetails.jsx"
 
 export const CompetitorViews = ({ currentUser }) => {
     return (
@@ -25,6 +26,7 @@ export const CompetitorViews = ({ currentUser }) => {
                 </Route>
                 <Route path="competitions">
                     <Route index element={<CompetitorCompetitionList currentUser={currentUser} />} />
+                    <Route path="details" element={<CompetitorCompetitionDetails currentUser={currentUser} />} />
                 </Route>
                 <Route path="leagueLeaderboard">
                     <Route index element={<LeagueLeaderboard currentUser={currentUser} />} />


### PR DESCRIPTION
## What Changed

- Added a component to display details about competitions (competition leaderboard for competitor views)
- Filtered the dropdown on the competitor scorecard page to show competitions that have been started only

## How To Test

- Login as competitor
- Click competitions in navbar
- Click one of the buttons with a competition name as its label
- If the competition has been started, you'll see a leaderboard (0 points each if no competitor has logged a climb on their scorecard yet)
- If the competition hasn't been started yet, nothing will be displayed in the table
-----------------------------------------------------------------------
- Click the scorecard button in the navbar
- Click the dropdown
- Only competitions that have been started will show in the dropdown